### PR TITLE
Fix for #6 & Use callLoginMethod from provided AccountsClient instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ Gives the possibility to set a custom accounts instance to be used for the login
 
 ## Testing
 
-You can test this dependency by running `npm run test`
+You can test this dependency by running `npm run test` or check the recent results from circleci & travis-ci

--- a/client/index.js
+++ b/client/index.js
@@ -31,11 +31,13 @@ class RememberMe {
      *  @returns {function} loginWithPassword
      *  @private
      */
-    getLoginWithPasswordMethod() {
-        return this.remoteConnection
-            ? this.remoteConnection.loginWithPassword
-            : Meteor.loginWithPassword;
-    }
+    getLoginWithPasswordMethod = () => {
+        if (this.remoteConnection) {
+            return this.remoteConnection.loginWithPassword;
+        }
+
+        return Meteor.loginWithPassword;
+    };
 
     /**
      *  Returns call method either from the main
@@ -43,11 +45,13 @@ class RememberMe {
      *  @returns {function} call
      *  @private
      */
-    getCallMethod() {
-        return this.remoteConnection
-            ? this.remoteConnection.call.bind(this.remoteConnection)
-            : Meteor.call;
-    }
+    getCallMethod = () => {
+        if (this.remoteConnection) {
+            return this.remoteConnection.call.bind(this.remoteConnection);
+        }
+
+        return Meteor.call;
+    };
 
     /**
      *  Wrapper for the Meteor.loginWithPassword
@@ -57,7 +61,7 @@ class RememberMe {
      *  update the rememberMe flag on the server side.
      *  @public
      */
-    loginWithPassword(...params) {
+    loginWithPassword = (...params) => {
         const [user, password, ...rest] = params;
         const flag = exportFlagFromParams(rest);
         const callbackMethod = exportCallbackFromParams(rest);
@@ -68,7 +72,7 @@ class RememberMe {
             }
             callbackMethod(error);
         });
-    }
+    };
 
     /**
      *  Sends request to the server to update
@@ -76,7 +80,7 @@ class RememberMe {
      *  @param {boolean} flag
      *  @private
      */
-    updateFlag(flag) {
+    updateFlag = (flag) => {
         const callMethod = this.getCallMethod();
         callMethod(this.methodName, flag, (error) => {
             if (error && error.error === 404) {
@@ -94,7 +98,7 @@ class RememberMe {
                 );
             }
         });
-    }
+    };
 
     /**
      *  Switches from using the current login system to
@@ -104,7 +108,7 @@ class RememberMe {
      *  @returns {boolean} result
      *  @public
      */
-    changeAccountsSystem(customAccounts) {
+    changeAccountsSystem = (customAccounts) => {
         if (customAccounts instanceof AccountsClient &&
             customAccounts.connection) {
             this.remoteConnection = customAccounts.connection;
@@ -115,7 +119,7 @@ class RememberMe {
         console.error('meteor/tprzytula:remember-me' +
             '\nProvided parameter is not a valid AccountsClient.');
         return false;
-    }
+    };
 
     /**
      *  Since freshly created AccountsClients are not having
@@ -123,7 +127,7 @@ class RememberMe {
      *  the set accounts system will contain it.
      *  @private
      */
-    setLoginMethod() {
+    setLoginMethod = () => {
         if ('loginWithPassword' in this.remoteConnection) {
             // Login method is already present
             return;
@@ -162,7 +166,7 @@ class RememberMe {
             });
         };
         /* eslint-enable */
-    }
+    };
 }
 
 export default new RememberMe();

--- a/client/index.js
+++ b/client/index.js
@@ -112,7 +112,7 @@ class RememberMe {
         if (customAccounts instanceof AccountsClient &&
             customAccounts.connection) {
             this.remoteConnection = customAccounts.connection;
-            this.setLoginMethod();
+            this.setLoginMethod(customAccounts);
             overrideAccountsLogin(customAccounts);
             return true;
         }
@@ -125,9 +125,10 @@ class RememberMe {
      *  Since freshly created AccountsClients are not having
      *  this method by default it's required to make sure that
      *  the set accounts system will contain it.
+     *  @param {AccountsClient} accountsInstance
      *  @private
      */
-    setLoginMethod = () => {
+    setLoginMethod = (accountsInstance) => {
         if ('loginWithPassword' in this.remoteConnection) {
             // Login method is already present
             return;
@@ -144,7 +145,7 @@ class RememberMe {
                     ? { username: selector }
                     : { email: selector };
             }
-            Meteor.remoteUsers.callLoginMethod({
+            accountsInstance.callLoginMethod({
                 methodArguments: [{
                     user: selector,
                     password: Accounts._hashPassword(password)

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.1] - 10.05.2018
+* Change client methods to arrow functions to prevent wrong context issues ([Issue #6](https://github.com/tprzytula/Meteor-Remember-Me/issues/6))
+* loginWithPassword method for custom accounts was throwing an error if accounts were not stored in `Meteor.remoteUsers` (whoops!)
+
 ## [0.2.0] - 13.03.2018
 New feature:
 * Add support for custom AccountsClient ([introduction](CUSTOM_ACCOUNTS.md))

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.44.tgz",
       "integrity": "sha512-4r2bym+kePWQH3eLne/IqVwqzbk43Lt6rzYQM+ARwSHfned1rFg9SX62SdKHtzSYq8NCoULxwHJS0T6a6r5hiA==",
+      "dev": true,
       "requires": {
         "core-js": "2.5.5",
         "regenerator-runtime": "0.11.1"
@@ -823,7 +824,8 @@
     "core-js": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2667,7 +2669,8 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
     name: 'tprzytula:remember-me',
-    version: '0.2.0',
+    version: '0.2.1',
     summary: 'Extension for Meteor account-base package with the implementation of rememberMe',
     git: 'https://github.com/tprzytulacc/Meteor-RememberMe',
     documentation: 'doc/README.md'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rememberMe",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Extension for Meteor account-base package with the implementation of rememberMe",
   "license": "MIT",
   "author": "Tomasz Przytuła <t.przytula.dev@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "eslint": "eslint ./client ./server ./test || true",
     "eslint-check": "eslint ./client ./server ./test",
     "eslint-fix": "eslint ./client ./server ./test --fix || true",
-    "test": "cross-env TEST_BROWSER_DRIVER=chrome meteor test --once --driver-package meteortesting:mocha"
+    "test": "cross-env TEST_BROWSER_DRIVER=chrome meteor test --once --driver-package meteortesting:mocha",
+    "test-watch": "cross-env WATCH=1 TEST_BROWSER_DRIVER=chrome meteor test --driver-package meteortesting:mocha"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.0.0-beta.44",
     "babel-eslint": "^8.2.2",
     "bcrypt": "^2.0.0",
     "chromedriver": "^2.37.0",
@@ -36,9 +38,6 @@
     "selenium-webdriver": "3.0.0-beta-2",
     "sinon": "^4.5.0",
     "ultimate-chai": "^4.1.1"
-  },
-  "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.44"
   },
   "pre-commit": [
     "eslint-check",

--- a/test/server/utils/testUser.js
+++ b/test/server/utils/testUser.js
@@ -1,3 +1,4 @@
+const { Accounts } = require('meteor/accounts-base');
 const Authenticator = require('./../../../server/authenticator').default;
 
 /**


### PR DESCRIPTION
* fixes #6 
* For custom accounts system the `callLoginMethod` is now being used from provided `AccountsClient` instance instead of getting it from `Meteor.remoteUsers`